### PR TITLE
Prevent `from * import *` to be splitted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 autoflake.egg-info/
 /.coverage
 /pypi_tmp/
+/tmp.*/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 dist/
 htmlcov/
 autoflake.egg-info/
+/.coverage
+/pypi_tmp/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,6 +2,7 @@ Author
 ------
 - Steven Myint (https://github.com/myint)
 
-Patches
--------
+Contributors
+------------
 - tell-k (https://github.com/tell-k)
+- Adhika Setya Pramudita (https://github.com/adhikasp)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include test_autoflake.py
 exclude .travis.yml
 exclude Makefile
 exclude test_acid.py
+exclude test_acid_pypi.py

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ check:
 	pylint \
 		--reports=no \
 		--disable=invalid-name,no-member,too-few-public-methods,no-else-return \
+		--disable=redefined-builtin \
 		--rcfile=/dev/null \
 		autoflake.py setup.py
 	pydocstyle autoflake.py setup.py

--- a/autoflake.py
+++ b/autoflake.py
@@ -239,13 +239,14 @@ def filter_from_import(line, unused_module):
 
     # All of the import in this statement is unused
     if not filtered_imports:
-        return get_indentation(line) + 'pass' + \
-            get_line_ending(line)
+        return get_indentation(line) + 'pass' + get_line_ending(line)
 
     indentation += 'import '
 
-    return indentation + ', '.join(sorted(filtered_imports)) \
-        + get_line_ending(line)
+    return (
+        indentation +
+        ', '.join(sorted(filtered_imports)) +
+        get_line_ending(line))
 
 
 def break_up_import(line):

--- a/autoflake.py
+++ b/autoflake.py
@@ -106,6 +106,7 @@ def unused_import_line_numbers(messages):
         if isinstance(message, pyflakes.messages.UnusedImport):
             yield message.lineno
 
+
 def unused_import_module_name(messages):
     """Yield line number and module name of unused imports."""
     pattern = r'\'(.+?)\''
@@ -113,8 +114,9 @@ def unused_import_module_name(messages):
         if isinstance(message, pyflakes.messages.UnusedImport):
             module_name = re.search(pattern, str(message))
             module_name = module_name.group()[1:-1]
-            if (module_name):
+            if module_name:
                 yield (message.lineno, module_name)
+
 
 def unused_variable_line_numbers(messages):
     """Yield line numbers of unused variables."""
@@ -213,17 +215,17 @@ def multiline_statement(line, previous_line=''):
         return True
 
 
-def filter_from_import(line, unused_module, debug=False):
-    """
-    Parse and filter ``from something import a, b, c``
-    
-    Return line without unused import modules, or `pass` if 
-    all of the module in import is unused.
+def filter_from_import(line, unused_module):
+    """Parse and filter ``from something import a, b, c``.
+
+    Return line without unused import modules, or `pass` if all of the
+    module in import is unused.
+
     """
     (indentation, imports) = re.split(pattern=r'\bimport\b',
                                       string=line, maxsplit=1)
-    base_module = re.search(pattern='from\s+([^ ]+)',
-                           string=indentation).group(1)
+    base_module = re.search(pattern=r'from\s+([^ ]+)',
+                            string=indentation).group(1)
 
     # Create an imported module list with base module name
     # ex ``from a import b, c as d`` -> ``['a.b', 'a.c as d']``
@@ -243,7 +245,7 @@ def filter_from_import(line, unused_module, debug=False):
     indentation += 'import '
 
     return indentation + ', '.join(sorted(filtered_imports)) \
-           + get_line_ending(line)
+        + get_line_ending(line)
 
 
 def break_up_import(line):

--- a/test_acid.py
+++ b/test_acid.py
@@ -93,7 +93,7 @@ def run(filename, command, verbose=False, options=None):
                 try:
                     check_syntax(temp_filename, raise_error=True)
                 except (SyntaxError, TypeError,
-                        UnicodeDecodeError) as exception:
+                        UnicodeDecodeError, ValueError) as exception:
                     sys.stderr.write('autoflake broke ' + filename + '\n' +
                                      str(exception) + '\n')
                     return False
@@ -121,7 +121,7 @@ def check_syntax(filename, raise_error=False):
         try:
             compile(input_file.read(), '<string>', 'exec', dont_inherit=True)
             return True
-        except (SyntaxError, TypeError, UnicodeDecodeError):
+        except (SyntaxError, TypeError, UnicodeDecodeError, ValueError):
             if raise_error:
                 raise
             else:

--- a/test_acid_pypi.py
+++ b/test_acid_pypi.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+"""Run acid test against latest packages on PyPI."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+import test_acid
+
+
+TMP_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                       'pypi_tmp')
+
+
+def latest_packages(last_hours):
+    """Return names of latest released packages on PyPI."""
+    process = subprocess.Popen(
+        ['yolk', '--latest-releases={hours}'.format(hours=last_hours)],
+        stdout=subprocess.PIPE)
+
+    for line in process.communicate()[0].decode('utf-8').split('\n'):
+        if line:
+            yield line.split()[0]
+
+
+def download_package(name, output_directory):
+    """Download package to output_directory.
+
+    Raise CalledProcessError on failure.
+
+    """
+    subprocess.check_call(['yolk', '--fetch-package={name}'.format(name=name)],
+                          cwd=output_directory)
+
+
+def extract_package(path, output_directory):
+    """Extract package at path."""
+    if path.lower().endswith('.tar.gz'):
+        try:
+            tar = tarfile.open(path)
+            tar.extractall(path=output_directory)
+            tar.close()
+            return True
+        except (tarfile.ReadError, IOError):
+            return False
+    elif path.lower().endswith('.zip'):
+        try:
+            archive = zipfile.ZipFile(path)
+            archive.extractall(path=output_directory)
+            archive.close()
+        except (zipfile.BadZipfile, IOError):
+            return False
+        return True
+
+    return False
+
+
+def main():
+    """Run main."""
+    try:
+        os.mkdir(TMP_DIR)
+    except OSError:
+        pass
+
+    args = test_acid.process_args()
+    if args.files:
+        # Copy
+        names = list(args.files)
+    else:
+        names = None
+
+    checked_packages = []
+    skipped_packages = []
+    last_hours = 1
+    while True:
+        if args.files:
+            if not names:
+                break
+        else:
+            while not names:
+                # Continually populate if user did not specify a package
+                # explicitly.
+                names = [p for p in latest_packages(last_hours)
+                         if p not in checked_packages and
+                         p not in skipped_packages]
+
+                if not names:
+                    last_hours *= 2
+
+        package_name = names.pop(0)
+        print(package_name, file=sys.stderr)
+
+        package_tmp_dir = os.path.join(TMP_DIR, package_name)
+        try:
+            os.mkdir(package_tmp_dir)
+        except OSError:
+            print('Skipping already checked package', file=sys.stderr)
+            skipped_packages.append(package_name)
+            continue
+
+        try:
+            download_package(
+                package_name,
+                output_directory=package_tmp_dir)
+        except subprocess.CalledProcessError:
+            print('yolk fetch failed', file=sys.stderr)
+            continue
+
+        for download_name in os.listdir(package_tmp_dir):
+            try:
+                if not extract_package(
+                        os.path.join(package_tmp_dir, download_name),
+                        output_directory=package_tmp_dir):
+                    print('Could not extract package', file=sys.stderr)
+                    continue
+            except UnicodeDecodeError:
+                print('Could not extract package', file=sys.stderr)
+                continue
+
+            args.files = [package_tmp_dir]
+            if test_acid.check(args):
+                checked_packages.append(package_name)
+            else:
+                return 1
+
+    if checked_packages:
+        print('\nTested packages:\n    ' + '\n    '.join(checked_packages),
+              file=sys.stderr)
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -194,15 +194,15 @@ x = 1
 
     def test_filter_code_with_used_from(self):
         self.assertEqual(
-                """\
+            """\
 import frommer
 print(frommer)
 """,
-                ''.join(autoflake.filter_code("""\
+            ''.join(autoflake.filter_code("""\
 import frommer
 print(frommer)
 """,
-                                              remove_all_unused_imports=True)))
+                                          remove_all_unused_imports=True)))
 
     def test_filter_code_with_ambiguous_from(self):
         self.assertEqual(
@@ -210,7 +210,7 @@ print(frommer)
 pass
 """,
             ''.join(autoflake.filter_code("""\
-from frommy import abc, frommy, xyz
+from frommer import abc, frommer, xyz
 """,
                                           remove_all_unused_imports=True)))
 
@@ -335,27 +335,27 @@ import os, math, subprocess
 
     def test_filter_from_import_no_remove(self):
         self.assertEqual(
-                """\
+            """\
     from foo import abc, math, subprocess\n""",
-                autoflake.filter_from_import(
-                    '    from foo import abc, subprocess, math\n',
-                    unused_module=[]))
+            autoflake.filter_from_import(
+                '    from foo import abc, subprocess, math\n',
+                unused_module=[]))
 
     def test_filter_from_import_remove_module(self):
         self.assertEqual(
-                """\
+            """\
     from foo import math, subprocess\n""",
-                autoflake.filter_from_import(
-                    '    from foo import abc, subprocess, math\n',
-                    unused_module=['foo.abc']))
+            autoflake.filter_from_import(
+                '    from foo import abc, subprocess, math\n',
+                unused_module=['foo.abc']))
 
     def test_filter_from_import_remove_all(self):
         self.assertEqual(
-                    '    pass\n',
-                autoflake.filter_from_import(
-                    '    from foo import abc, subprocess, math\n',
-                    unused_module=['foo.abc', 'foo.subprocess',
-                                   'foo.math']))
+            '    pass\n',
+            autoflake.filter_from_import(
+                '    from foo import abc, subprocess, math\n',
+                unused_module=['foo.abc', 'foo.subprocess',
+                               'foo.math']))
 
     def test_filter_code_should_ignore_multiline_imports(self):
         self.assertEqual(
@@ -522,7 +522,7 @@ def z():
     from ctypes import POINTER, byref
     POINTER, byref
     """,
-                autoflake.fix_code("""\
+            autoflake.fix_code("""\
 def z():
     from ctypes import c_short, c_uint, c_int, c_long, pointer, POINTER, byref
     POINTER, byref

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -494,6 +494,20 @@ namedtuple
 from collections import defaultdict as abc, namedtuple as xyz
 """))
 
+    def test_fix_code_with_from_with_and_without_remove_all(self):
+        code = """\
+from x import a as b, c as d
+"""
+
+        self.assertEqual(
+            """\
+""",
+            autoflake.fix_code(code, remove_all_unused_imports=True))
+
+        self.assertEqual(
+            code,
+            autoflake.fix_code(code, remove_all_unused_imports=False))
+
     def test_fix_code_with_from_and_depth_module(self):
         self.assertEqual(
             """\

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1094,7 +1094,7 @@ def temporary_file(contents, directory='.', prefix=''):
 
 
 @contextlib.contextmanager
-def temporary_directory(directory='.', prefix=''):
+def temporary_directory(directory='.', prefix='tmp.'):
     """Create temporary directory and yield its path."""
     temp_directory = tempfile.mkdtemp(prefix=prefix, dir=directory)
     try:


### PR DESCRIPTION
This will prevent a `from something import a, b, c`  to be splitted.

Test code 
```python
from math import sqrt, log, tan, cos
import os, sys, collections

print(log(2))
print(tan(5))
print(os)
print(sys)
```

Result
```diff
--- original/tes.py
+++ fixed/tes.py
@@ -1,5 +1,6 @@
-from math import sqrt, log, tan, cos
-import os, sys, collections
+from math import log, tan
+import os
+import sys

 print(log(2))
 print(tan(5))
```

Closes https://github.com/myint/autoflake/issues/7