### PR TITLE
Add option to expand single star import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,11 +91,11 @@ To remove unused variables, use the ``--remove-unused-variables`` option.
 Below is the full listing of options::
 
     usage: autoflake [-h] [-i] [-r] [--imports IMPORTS]
-                     [--remove-all-unused-imports] [--remove-unused-variables]
-                     [--version]
+                     [--expand-single-star-import] [--remove-all-unused-imports]
+                     [--remove-unused-variables] [--version]
                      files [files ...]
 
-    Removes unused imports as reported by pyflakes.
+    Removes unused imports and unused variables as reported by pyflakes.
 
     positional arguments:
       files                 files to format
@@ -107,9 +107,11 @@ Below is the full listing of options::
       --imports IMPORTS     by default, only unused standard library imports are
                             removed; specify a comma-separated list of additional
                             modules/packages
+      --expand-single-star-import
+                            expand wildcard star import with undefined names
       --remove-all-unused-imports
                             remove all unused imports (not just those from the
-                            standard library
+                            standard library)
       --remove-unused-variables
                             remove unused variables
       --version             show program's version number and exit

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -96,6 +96,17 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(' \t ', autoflake.get_indentation(' \t abc  \n\t'))
         self.assertEqual('', autoflake.get_indentation('    '))
 
+    def test_filter_star_import(self):
+        self.assertEqual(
+            'from math import cos',
+            autoflake.filter_star_import('from math import *',
+                                         ['cos']))
+
+        self.assertEqual(
+            'from math import cos, sin',
+            autoflake.filter_star_import('from math import *',
+                                         ['sin', 'cos']))
+
     def test_filter_unused_variable(self):
         self.assertEqual('foo()',
                          autoflake.filter_unused_variable('x = foo()'))
@@ -291,6 +302,45 @@ import re  # noqa
 from subprocess import Popen  # NOQA
 x = 1
 """)))
+
+    def test_filter_code_expand_star_import(self):
+        self.assertEqual(
+            """\
+from math import sin
+sin(1)
+""",
+            ''.join(autoflake.filter_code("""\
+from math import *
+sin(1)
+""", expand_star_import=True)))
+
+        self.assertEqual(
+            """\
+from math import cos, sin
+sin(1)
+cos(1)
+""",
+            ''.join(autoflake.filter_code("""\
+from math import *
+sin(1)
+cos(1)
+""", expand_star_import=True)))
+
+    def test_filter_code_ignore_multiple_star_import(self):
+        self.assertEqual(
+            """\
+from math import *
+from re import *
+sin(1)
+cos(1)
+""",
+            ''.join(autoflake.filter_code("""\
+from math import *
+from re import *
+sin(1)
+cos(1)
+""", expand_star_import=True)))
+
 
     def test_multiline_import(self):
         self.assertTrue(autoflake.multiline_import(r"""\

--- a/test_fuzz.py
+++ b/test_fuzz.py
@@ -142,6 +142,9 @@ def process_args():
     parser.add_argument('--command', default=AUTOFLAKE_BIN,
                         help='autoflake command (default: %(default)s)')
 
+    parser.add_argument('--expand-star-import', action='store_true',
+                        help='expand wildcard star import with undefined names')
+
     parser.add_argument('--imports',
                         help='pass to the autoflake "--imports" option')
 
@@ -174,6 +177,9 @@ def check(args):
                      if os.path.isdir(path)]
 
     options = []
+    if args.expand_star_import:
+        options.append('--expand-star-import')
+
     if args.imports:
         options.append('--imports=' + args.imports)
 


### PR DESCRIPTION
This patch add new feature to automatically expand a star 
(wildcard) import to specify all names that used inside the code.

A sample code like this

```python
from math import *
sin(1)
cos(0)
```

will be changed into 

```python
from math import cos, sin
sin(1)
cos(0)
```

Note that there are still 2 bugs regarding this feature, 
which mainly caused by related upstream bug from pyflakes:

1. A function/names that declared but later deleted by `del` 
   command will raise a false positive that the names is
   undeclared and could possibly come from a star import 
   (if present).
   https://github.com/PyCQA/pyflakes/issues/175
2. pyflakes is "inconsistent" on defining an undefined var 
   in case of `__all__ `is used (like in module API files).
   
```python
from foo import * # contain function_1 and function_2

__all__ = ['function_1', 'function_2', 'function_3']

function_2() # just use it somewhere to trigger pyflake

def function_3:
    return 'something'
```

pyflakes will complain that function_2 is undefined and 
possibly come from module foo. The import then will be 
expanded into...

```python
from foo import function_2
```

But then pyflakes will complain function_1 is undefined 
because it's used in `__all__`.

Closes https://github.com/myint/autoflake/issues/14