### PR TITLE
Keep unused import and pass statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Below is the full listing of options::
                             this only triggers if there is only one star import in
                             the file; this is skipped if there are any uses of
                             `__all__` or `del` in the file
+      --keep-unused-import  keep unused import
       --keep-useless-pass   keep useless pass statement
       --remove-all-unused-imports
                             remove all unused imports (not just those from the

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Below is the full listing of options::
                             this only triggers if there is only one star import in
                             the file; this is skipped if there are any uses of
                             `__all__` or `del` in the file
+      --keep-useless-pass   keep useless pass statement
       --remove-all-unused-imports
                             remove all unused imports (not just those from the
                             standard library)

--- a/autoflake.py
+++ b/autoflake.py
@@ -497,7 +497,8 @@ def get_line_ending(line):
 
 
 def fix_code(source, additional_imports=None, expand_star_imports=False,
-             remove_all_unused_imports=False, remove_unused_variables=False):
+             remove_all_unused_imports=False, remove_unused_variables=False,
+             remove_useless_pass=True):
     """Return code with all filtering run on it."""
     if not source:
         return source
@@ -508,14 +509,14 @@ def fix_code(source, additional_imports=None, expand_star_imports=False,
 
     filtered_source = None
     while True:
-        filtered_source = ''.join(
-            filter_useless_pass(''.join(
-                filter_code(
-                    source,
-                    additional_imports=additional_imports,
-                    expand_star_imports=expand_star_imports,
-                    remove_all_unused_imports=remove_all_unused_imports,
-                    remove_unused_variables=remove_unused_variables))))
+        filtered_source = ''.join(filter_code(
+            source,
+            additional_imports=additional_imports,
+            expand_star_imports=expand_star_imports,
+            remove_all_unused_imports=remove_all_unused_imports,
+            remove_unused_variables=remove_unused_variables))
+        if remove_useless_pass:
+            filtered_source = ''.join(filter_useless_pass(filtered_source))
 
         if filtered_source == source:
             break
@@ -537,7 +538,9 @@ def fix_file(filename, args, standard_out):
         additional_imports=args.imports.split(',') if args.imports else None,
         expand_star_imports=args.expand_star_imports,
         remove_all_unused_imports=args.remove_all_unused_imports,
-        remove_unused_variables=args.remove_unused_variables)
+        remove_unused_variables=args.remove_unused_variables,
+        remove_useless_pass=not args.keep_useless_pass,
+    )
 
     if original_source != filtered_source:
         if args.in_place:
@@ -692,6 +695,8 @@ def _main(argv, standard_out, standard_error):
                              'one star import in the file; this is skipped if '
                              'there are any uses of `__all__` or `del` in the '
                              'file')
+    parser.add_argument('--keep-useless-pass', action='store_true',
+                        help='keep useless pass statement')
     parser.add_argument('--remove-all-unused-imports', action='store_true',
                         help='remove all unused imports (not just those from '
                              'the standard library)')

--- a/autoflake.py
+++ b/autoflake.py
@@ -723,7 +723,8 @@ def _main(argv, standard_out, standard_error):
     args = parser.parse_args(argv[1:])
 
     if args.remove_all_unused_imports and args.imports:
-        print('Using both --remove-all and --imports is redundant',
+        print('Using both --remove-all-unused-imports and --imports is '
+              'redundant',
               file=standard_error)
         return 1
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -690,6 +690,13 @@ def main():
             code,
             autoflake.fix_code(code))
 
+    def test_fix_code_not_remove_pass(self):
+        code = 'pass'
+        self.assertEqual(
+            code,
+            autoflake.fix_code(code,
+                remove_useless_pass=False))
+
     def test_useless_pass_line_numbers(self):
         self.assertEqual(
             [1],

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -341,6 +341,13 @@ sin(1)
 cos(1)
 """, expand_star_imports=True)))
 
+    def test_filter_code_not_remove_import(self):
+        code = 'import math'
+        self.assertEqual(
+            code,
+            ''.join(autoflake.filter_code(code,
+                remove_unused_import=False)))
+
     def test_multiline_import(self):
         self.assertTrue(autoflake.multiline_import(r"""\
 import os, \


### PR DESCRIPTION
Make it possible to provide CLI args to keep autoflake from removing useless pass (`--keep-useless-pass`) and unused import (`--keep-unused-import`)

Closes https://github.com/myint/autoflake/issues/13 https://github.com/myint/autoflake/issues/10