### PR TITLE
Remove duplicate dictionary keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 
 after_success:
     - pip install --quiet coverage
-    - AUTOFLAKE_COVERAGE=1 coverage run --include='autoflake.py,test_autoflake.py' test_autoflake.py
+    - AUTOFLAKE_COVERAGE=1 coverage run --branch --parallel-mode --include='autoflake.py,test_autoflake.py' test_autoflake.py
     - coverage combine
     - coverage report --show-missing
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 after_success:
     - pip install --quiet coverage
     - AUTOFLAKE_COVERAGE=1 coverage run --include='autoflake.py,test_autoflake.py' test_autoflake.py
+    - coverage combine
     - coverage report --show-missing
 
     - pip install --quiet coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 
 after_success:
     - pip install --quiet coverage
-    - coverage run --include='autoflake.py,test_autoflake.py' test_autoflake.py
+    - AUTOFLAKE_COVERAGE=1 coverage run --include='autoflake.py,test_autoflake.py' test_autoflake.py
     - coverage report --show-missing
 
     - pip install --quiet coveralls

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 
 coverage:
 	@coverage erase
-	@coverage run test_autoflake.py
+	@AUTOFLAKE_COVERAGE=1 coverage run test_autoflake.py
 	@coverage report
 	@coverage html
 	@python -m webbrowser -n "file://${PWD}/htmlcov/index.html"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ check:
 coverage:
 	@coverage erase
 	@AUTOFLAKE_COVERAGE=1 coverage run test_autoflake.py
+	@coverage combine
 	@coverage report
 	@coverage html
 	@python -m webbrowser -n "file://${PWD}/htmlcov/index.html"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 
 coverage:
 	@coverage erase
-	@AUTOFLAKE_COVERAGE=1 coverage run test_autoflake.py
+	@AUTOFLAKE_COVERAGE=1 coverage run --branch --parallel-mode --include='autoflake.py,test_autoflake.py' test_autoflake.py
 	@coverage combine
 	@coverage report
 	@coverage html


### PR DESCRIPTION
This will automatically remove duplicate dictionary keys with the
`--remove-duplicate-keys` argument.

Closes https://github.com/myint/autoflake/issues/27

## Example

```diff
--- original/../test.py
+++ fixed/../test.py
@@ -1,15 +1,9 @@
 print({
-  'b': 456,
-  'a': 123,
-  'b': 7834,
   'a': 'wow',
-  'b': 456,
-  'c': 'hello',
   'c': 'hello2',
-  'b': 'hiya',
   'b': 'hiya',
 })
 
-print({ 'a': 123, 'a': 567 })
-print({ 'b': 123, 'b': 567, 'b': 897, 'c': 'hello' })
-print({ 'a': 'first value', 'c': 123, 'd': 'hjfkds', 'c': 567, 'g': 'hi', 'c': 'this value will stay', 'd': 'so will this one' })
+print({ 'a': 567 })
+print({ 'b': 897, 'c': 'hello' })
+print({ 'a': 'first value', 'g': 'hi', 'c': 'this value will stay', 'd': 'so will this one' })
```