### PR TITLE
reflected exclude option when use glob

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -615,7 +615,7 @@ def fix_code(source, additional_imports=None, expand_star_imports=False,
                     remove_duplicate_keys=remove_duplicate_keys,
                     remove_unused_variables=remove_unused_variables,
                     ignore_init_module_imports=ignore_init_module_imports,
-                    ))))
+                ))))
 
         if filtered_source == source:
             break
@@ -647,7 +647,7 @@ def fix_file(filename, args, standard_out):
         remove_duplicate_keys=args.remove_duplicate_keys,
         remove_unused_variables=args.remove_unused_variables,
         ignore_init_module_imports=ignore_init_module_imports,
-        )
+    )
 
     if original_source != filtered_source:
         if args.in_place:
@@ -745,18 +745,25 @@ def is_python_file(filename):
     return True
 
 
-def match_file(filename, exclude):
-    """Return True if file is okay for modifying/recursing."""
+def is_exclude_file(filename, exclude):
+    """Return True if file matches exclude pattern."""
     base_name = os.path.basename(filename)
 
     if base_name.startswith('.'):
-        return False
+        return True
 
     for pattern in exclude:
         if fnmatch.fnmatch(base_name, pattern):
-            return False
+            return True
         if fnmatch.fnmatch(filename, pattern):
-            return False
+            return True
+    return False
+
+
+def match_file(filename, exclude):
+    """Return True if file is okay for modifying/recursing."""
+    if is_exclude_file(filename, exclude):
+        return False
 
     if not os.path.isdir(filename) and not is_python_file(filename):
         return False
@@ -777,7 +784,8 @@ def find_files(filenames, recursive, exclude):
                                   if match_file(os.path.join(root, d),
                                                 exclude)]
         else:
-            yield name
+            if not is_exclude_file(name, exclude):
+                yield name
 
 
 def _main(argv, standard_out, standard_error):

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1191,6 +1191,23 @@ def func11():
         self.assertFalse(autoflake.is_python_file(os.devnull))
         self.assertFalse(autoflake.is_python_file('/bin/bash'))
 
+    def test_is_exclude_file(self):
+        self.assertTrue(autoflake.is_exclude_file(
+            "1.py", ["test*", "1*"]))
+
+        self.assertFalse(autoflake.is_exclude_file(
+            "2.py", ["test*", "1*"]))
+
+        # folder glob
+        self.assertTrue(autoflake.is_exclude_file(
+            "test/test.py", ["test/**.py"]))
+
+        self.assertTrue(autoflake.is_exclude_file(
+            "test/auto_test.py", ["test/*_test.py"]))
+
+        self.assertFalse(autoflake.is_exclude_file(
+            "test/auto_auto.py", ["test/*_test.py"]))
+
     def test_match_file(self):
         with temporary_file('', suffix='.py', prefix='.') as filename:
             self.assertFalse(autoflake.match_file(filename, exclude=[]),


### PR DESCRIPTION
When use `--exclude` option and glob pattern (ex: `test/**.py`) , exclude option is not reflected. I think exclude option should be reflected when specify files as same as specify folder.