### PR TITLE
Add check argument

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 - Adhika Setya Pramudita (https://github.com/adhikasp)
 - Andrew Dassonville (https://github.com/andrewda)
 - toddrme2178 (https://github.com/toddrme2178)
+- James Curtin (https://github.com/jamescurtin)

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ Below is the full listing of options::
 
     optional arguments:
       -h, --help            show this help message and exit
+      -c, --check           return error code if changes are needed
       -i, --in-place        make changes to files instead of printing diffs
       -r, --recursive       drill down directories recursively
       --exclude globs       exclude file/directory names that match these comma-

--- a/autoflake.py
+++ b/autoflake.py
@@ -650,6 +650,9 @@ def fix_file(filename, args, standard_out):
     )
 
     if original_source != filtered_source:
+        if args.check:
+            standard_out.write('Unused imports/variables detected.')
+            sys.exit(1)
         if args.in_place:
             with open_with_encoding(filename, mode='w',
                                     encoding=encoding) as output_file:
@@ -660,6 +663,9 @@ def fix_file(filename, args, standard_out):
                 io.StringIO(filtered_source).readlines(),
                 filename)
             standard_out.write(''.join(diff))
+    else:
+        if args.check:
+            standard_out.write('No issues detected!')
 
 
 def open_with_encoding(filename, encoding, mode='r',
@@ -795,6 +801,8 @@ def _main(argv, standard_out, standard_error):
     """
     import argparse
     parser = argparse.ArgumentParser(description=__doc__, prog='autoflake')
+    parser.add_argument('-c', '--check', action='store_true',
+                        help='return error code if changes are needed')
     parser.add_argument('-i', '--in-place', action='store_true',
                         help='make changes to files instead of printing diffs')
     parser.add_argument('-r', '--recursive', action='store_true',

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1354,6 +1354,55 @@ except ImportError:
     pass
 """, f.read())
 
+
+    def test_check_with_empty_file(self):
+        line = ''
+
+        with temporary_file(line) as filename:
+            output_file = io.StringIO()
+            autoflake._main(argv=['my_fake_program', '--check', filename],
+                            standard_out=output_file,
+                            standard_error=None)
+            self.assertEqual('No issues detected!', output_file.getvalue())
+
+
+    def test_check_correct_file(self):
+        with temporary_file("""\
+import foo
+x = foo.bar
+print(x)
+""") as filename:
+            output_file = io.StringIO()
+            autoflake._main(argv=['my_fake_program', '--check', filename],
+                            standard_out=output_file,
+                            standard_error=None)
+            self.assertEqual('No issues detected!', output_file.getvalue())
+
+
+    def test_check_useless_pass(self):
+        with temporary_file("""\
+import foo
+x = foo
+import subprocess
+x()
+
+try:
+    pass
+    import os
+except ImportError:
+    pass
+    import os
+    import sys
+""") as filename:
+            output_file = io.StringIO()
+            with self.assertRaises(SystemExit) as cm:
+                autoflake._main(argv=['my_fake_program', '--check', filename],
+                                standard_out=output_file,
+                                standard_error=None)
+                self.assertEqual(cm.exception.code, 1)
+                self.assertEqual('Unused imports/variables detected.', output_file.getvalue())
+
+
     def test_in_place_with_empty_file(self):
         line = ''
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1354,7 +1354,6 @@ except ImportError:
     pass
 """, f.read())
 
-
     def test_check_with_empty_file(self):
         line = ''
 
@@ -1364,7 +1363,6 @@ except ImportError:
                             standard_out=output_file,
                             standard_error=None)
             self.assertEqual('No issues detected!', output_file.getvalue())
-
 
     def test_check_correct_file(self):
         with temporary_file("""\
@@ -1377,7 +1375,6 @@ print(x)
                             standard_out=output_file,
                             standard_error=None)
             self.assertEqual('No issues detected!', output_file.getvalue())
-
 
     def test_check_useless_pass(self):
         with temporary_file("""\
@@ -1400,8 +1397,8 @@ except ImportError:
                                 standard_out=output_file,
                                 standard_error=None)
                 self.assertEqual(cm.exception.code, 1)
-                self.assertEqual('Unused imports/variables detected.', output_file.getvalue())
-
+                self.assertEqual('Unused imports/variables detected.',
+                                 output_file.getvalue())
 
     def test_in_place_with_empty_file(self):
         line = ''


### PR DESCRIPTION
By specifying the `--check` argument, the program will exit with a code of 1. This is useful if using as part of a CI pipeline that should fail if changes are necessary.