### PR TITLE
Fix newline after printing "No issues detected" during check mode

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -665,7 +665,7 @@ def fix_file(filename, args, standard_out):
             standard_out.write(''.join(diff))
     else:
         if args.check:
-            standard_out.write('No issues detected!')
+            standard_out.write('No issues detected!\n')
 
 
 def open_with_encoding(filename, encoding, mode='r',

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1362,7 +1362,7 @@ except ImportError:
             autoflake._main(argv=['my_fake_program', '--check', filename],
                             standard_out=output_file,
                             standard_error=None)
-            self.assertEqual('No issues detected!', output_file.getvalue())
+            self.assertEqual('No issues detected!\n', output_file.getvalue())
 
     def test_check_correct_file(self):
         with temporary_file("""\
@@ -1374,7 +1374,7 @@ print(x)
             autoflake._main(argv=['my_fake_program', '--check', filename],
                             standard_out=output_file,
                             standard_error=None)
-            self.assertEqual('No issues detected!', output_file.getvalue())
+            self.assertEqual('No issues detected!\n', output_file.getvalue())
 
     def test_check_useless_pass(self):
         with temporary_file("""\


### PR DESCRIPTION
In check mode, we print "No issue detected" after checking a file, and if that file contains no errors. This leads to lines like:

No issues detected!No issues detected!No issues detected!

Add a \n to make this slightly better.